### PR TITLE
서울신용평가정보 자동완성 로직 개선 및 한글/영문 텍스트 업데이트 PR

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -56,7 +56,7 @@
         "description": ""
     },
     "birthday": {
-        "message": "Birthday",
+        "message": "Birthdate (YYYYMMDD)",
         "description": ""
     },
     "citizen": {
@@ -92,27 +92,27 @@
         "description": ""
     },
     "enter_name": {
-        "message": "Please enter a name",
+        "message": "Please enter a name.",
         "description": ""
     },
     "select_carrier": {
-        "message": "Please select a carrier",
+        "message": "Please select a carrier.",
         "description": ""
     },
     "check_number": {
-        "message": "Please check your mobile phone number",
+        "message": "Please check your mobile phone number.",
         "description": ""
     },
     "check_birthday": {
-        "message": "Please check your birthday (8 digits) (eg 19990204)",
+        "message": "Please check your birthdate.\n(Enter your birthdate in 8 digits. eg. 19990204)",
         "description": ""
     },
     "select_gender": {
-        "message": "Please select a gender",
+        "message": "Please select a gender.",
         "description": ""
     },
     "select_auth_method": {
-        "message": "Please select an authentication method",
+        "message": "Please select an authentication method.",
         "description": ""
     },
     "skt_MNVO_do_not_support_pass": {

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -56,7 +56,7 @@
         "description": ""
     },
     "birthday": {
-        "message": "생년월일",
+        "message": "생년월일 (YYYYMMDD)",
         "description": ""
     },
     "citizen": {
@@ -92,27 +92,27 @@
         "description": ""
     },
     "enter_name": {
-        "message": "이름을 입력하시오",
+        "message": "이름을 입력하세요.",
         "description": ""
     },
     "select_carrier": {
-        "message": "통신사를 선택하시오",
+        "message": "통신사를 선택하세요.",
         "description": ""
     },
     "check_number": {
-        "message": "휴대폰번호를 확인하시오",
+        "message": "휴대폰 번호를 확인하세요.",
         "description": ""
     },
     "check_birthday": {
-        "message": "생일을 확인하시오 (8자리) (예, 19990204)",
+        "message": "생년월일을 확인하세요.\n(생년월일 형식은 8자리입니다. 예: 19990204)",
         "description": ""
     },
     "select_gender": {
-        "message": "성별을 선택하시오",
+        "message": "성별을 선택하세요.",
         "description": ""
     },
     "select_auth_method": {
-        "message": "인증방식을 선택하시오",
+        "message": "인증방식을 선택하세요.",
         "description": ""
     },
     "skt_MNVO_do_not_support_pass": {

--- a/autofill.js
+++ b/autofill.js
@@ -293,7 +293,7 @@ window.onload = function () {
                         }
                     } else if (this.document.getElementById('userName')) {
                         if (profilesOb[spI].way == way.SMS) { // SMS인증을 원하는 경우
-                            if (isPC && this.document.querySelector("#sms_auth") && this.document.querySelector("#sms_auth").title != '선택됨') { //sms아닐때
+                            if (isPC && this.document.title.includes('PASS인증')) { // PASS인증인 경우
                                 this.document.querySelector("#sms_auth").click();
                             } else {
                                 this.document.getElementById('userName').value = profilesOb[spI].name;
@@ -305,8 +305,8 @@ window.onload = function () {
                                 }
                             }
                         } else if (profilesOb[spI].way == way.PASS) { // PASS인증을 원하는 경우
-                            if (isPC && this.document.querySelector("#qr_auth") && this.document.querySelector("#qr_auth").title != '선택됨') { //sms아닐때
-                                this.document.querySelector("#sms_auth").click();
+                            if (isPC && this.document.title.includes('문자(SMS)인증')) { // SMS인증인 경우
+                                this.document.querySelector("#header > ul > li:nth-child(1) > a").click(); // SMS인증창 html에서 #qr_auth이 사라짐. 임시 workaround 적용.
                             } else {
                                 this.document.getElementsByName('userName')[0].value = profilesOb[spI].name;
                                 this.document.getElementsByName('No')[0].value = profilesOb[spI].phone_number;


### PR DESCRIPTION
- 서울신용평가정보사의 html구조가 약간 바뀌어 자동완성시 다음 오류가 발생하는 문제를 해결했습니다.
```
Error handling response: TypeError: Cannot read properties of null (reading 'title')
    at chrome-extension://addlpjfhfhcpfidabkeecbdaebgpnaog/autofill.js:293:81
```
- 새로운 로직은 현재 활성화된 '탭'을 확인하는 대신 document.title의 문자열을 확인합니다.
- 서울신용평가정보사의 인증 페이지에서 sms인증 → pass인증으로 넘어갈 때 #sms_auth를 잘못 선택하는 오류를 수정했습니다.
  - 이때 탭의 id가 없어 직접 참조가 불가능하여 selector을 이용한 임시 workaround를 적용했습니다.
- 한글 오류 메시지를 딱딱한 `'-시오'`체 에서 `'-세요'`체로 업데이트하고 생년월일 관련 설명을 보충했습니다.
- 영어 메시지에 마침표를 추가하고 생년월일 관련 설명을 보충했습니다.